### PR TITLE
Refactor paginated API calls and TagsAsTasks regexp usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,19 @@ All notable changes to this project will be documented in this file.
 **Miscellaneous Tasks**
 
 - Update changelog target ([bce0418](https://github.com/gabor-boros/minutes/commit/bce04188d00affa16725d7dfd02f156d7e0b915c))
+- Update dependencies ([f1029a7](https://github.com/gabor-boros/minutes/commit/f1029a7da35c646f29750fef0ba8ae3b9056a2a6))
 
 **Refactor**
 
 - Rework client composition logic and remove unnecessary Toggl flag (#30) ([6658984](https://github.com/gabor-boros/minutes/commit/6658984618f7e3c156110f1ac2527390b468d0a8))
+- Add paginated API call helpers ([4e88bec](https://github.com/gabor-boros/minutes/commit/4e88bec04964c42a79329f311cb7bc3f53dadaca))
+- Use paginated call helpers ([901800f](https://github.com/gabor-boros/minutes/commit/901800f5fbc37f3702e7e6413c508db59966be78))
+- Use paginated call helpers ([6ddca80](https://github.com/gabor-boros/minutes/commit/6ddca804799e65525d7d913deeeb463d0e93bb32))
+- Parse TagsAsTasks as regexp ([bf32537](https://github.com/gabor-boros/minutes/commit/bf32537fa39efe3f6c93f9c7056c49115d3f5eb8))
+
+**Revert**
+
+- Remove unnecessary error ([1120133](https://github.com/gabor-boros/minutes/commit/112013353c6e5cb4478f1c44294790c304b1885c))
 
 ## [0.1.0] - 2021-10-20
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,13 +237,18 @@ func validateFlags() {
 }
 
 func getFetcher() (client.Fetcher, error) {
+	tagsAsTasksRegex, err := regexp.Compile(viper.GetString("tags-as-tasks-regex"))
+	if err != nil {
+		return nil, err
+	}
+
 	switch viper.GetString("source") {
 	case "clockify":
 		return clockify.NewFetcher(&clockify.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
 				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
-				TagsAsTasksRegex: viper.GetString("tags-as-tasks-regex"),
-				Timeout:          0,
+				TagsAsTasksRegex: tagsAsTasksRegex,
+				Timeout:          client.DefaultRequestTimeout,
 			},
 			TokenAuth: client.TokenAuth{
 				Header: "X-Api-Key",
@@ -256,8 +261,8 @@ func getFetcher() (client.Fetcher, error) {
 		return tempo.NewFetcher(&tempo.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
 				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
-				TagsAsTasksRegex: viper.GetString("tags-as-tasks-regex"),
-				Timeout:          0,
+				TagsAsTasksRegex: tagsAsTasksRegex,
+				Timeout:          client.DefaultRequestTimeout,
 			},
 			BasicAuth: client.BasicAuth{
 				Username: viper.GetString("tempo-username"),
@@ -269,8 +274,8 @@ func getFetcher() (client.Fetcher, error) {
 		return timewarrior.NewFetcher(&timewarrior.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
 				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
-				TagsAsTasksRegex: viper.GetString("tags-as-tasks-regex"),
-				Timeout:          0,
+				TagsAsTasksRegex: tagsAsTasksRegex,
+				Timeout:          client.DefaultRequestTimeout,
 			},
 			CLIClient: client.CLIClient{
 				Command:            viper.GetString("timewarrior-command"),
@@ -285,8 +290,8 @@ func getFetcher() (client.Fetcher, error) {
 		return toggl.NewFetcher(&toggl.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
 				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
-				TagsAsTasksRegex: viper.GetString("tags-as-tasks-regex"),
-				Timeout:          0,
+				TagsAsTasksRegex: tagsAsTasksRegex,
+				Timeout:          client.DefaultRequestTimeout,
 			},
 			BasicAuth: client.BasicAuth{
 				Username: viper.GetString("toggl-api-key"),
@@ -305,9 +310,7 @@ func getUploader() (client.Uploader, error) {
 	case "tempo":
 		return tempo.NewUploader(&tempo.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
-				TagsAsTasksRegex: viper.GetString("tags-as-tasks-regex"),
-				Timeout:          0,
+				TagsAsTasks: viper.GetBool("tags-as-tasks"),
 			},
 			BasicAuth: client.BasicAuth{
 				Username: viper.GetString("tempo-username"),

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -29,8 +29,6 @@ var (
 	ErrInvalidBasicAuth = errors.New("invalid basic auth params provided")
 	// ErrInvalidTokenAuth returns if the provided token is empty.
 	ErrInvalidTokenAuth = errors.New("invalid token auth params provided")
-	// ErrOauth2Callback returns if the Oauth2 provider returned an error.
-	ErrOauth2Callback = errors.New("the Oauth2 callback returned with error")
 )
 
 // BaseClientOpts specifies the common options the clients are using.
@@ -116,9 +114,9 @@ func NewTokenAuth(header string, tokenName string, token string) (Authenticator,
 	}
 
 	return &TokenAuth{
-		Header: header,
+		Header:    header,
 		TokenName: tokenName,
-		Token:  token,
+		Token:     token,
 	}, nil
 }
 

--- a/internal/pkg/client/client_test.go
+++ b/internal/pkg/client/client_test.go
@@ -337,6 +337,7 @@ func TestHTTPClient_Call(t *testing.T) {
 		Auth:    nil,
 		Headers: headers,
 		Data:    nil,
+		Timeout: client.DefaultRequestTimeout,
 	})
 
 	require.Nil(t, err, err)
@@ -374,6 +375,7 @@ func TestHTTPClient_Call_NoClientSet(t *testing.T) {
 		Auth:    nil,
 		Headers: headers,
 		Data:    nil,
+		Timeout: client.DefaultRequestTimeout,
 	})
 
 	require.Nil(t, err)
@@ -413,6 +415,7 @@ func TestHTTPClient_Call_POST(t *testing.T) {
 		Data: testData{
 			Message: "Test",
 		},
+		Timeout: client.DefaultRequestTimeout,
 	})
 
 	require.Nil(t, err)
@@ -454,6 +457,7 @@ func TestHTTPClient_Call_Auth(t *testing.T) {
 		Auth:    authMethod,
 		Headers: headers,
 		Data:    nil,
+		Timeout: client.DefaultRequestTimeout,
 	})
 
 	require.Nil(t, err)
@@ -488,6 +492,7 @@ func TestHTTPClient_Call_Failure(t *testing.T) {
 		Auth:    nil,
 		Headers: map[string]string{},
 		Data:    nil,
+		Timeout: client.DefaultRequestTimeout,
 	})
 
 	require.Error(t, err)

--- a/internal/pkg/client/clockify/clockify.go
+++ b/internal/pkg/client/clockify/clockify.go
@@ -71,10 +71,18 @@ type clockifyClient struct {
 	*client.HTTPClient
 	authenticator client.Authenticator
 	workspace     string
+
+	// TODO: opts.TagsAsTasksRegex should be a regexp to avoid this
+	tagsAsTasksRegex *regexp.Regexp
 }
 
-func (c *clockifyClient) parseEntries(fetchedEntries []FetchEntry, tagsAsTasksRegex *regexp.Regexp) worklog.Entries {
+func (c *clockifyClient) parseEntries(rawEntries interface{}) (worklog.Entries, error) {
 	var entries worklog.Entries
+
+	fetchedEntries, ok := rawEntries.([]FetchEntry)
+	if !ok {
+		return nil, fmt.Errorf("%v: %s", client.ErrFetchEntries, "cannot parse returned entries")
+	}
 
 	for _, entry := range fetchedEntries {
 		billableDuration := entry.TimeInterval.End.Sub(entry.TimeInterval.Start)
@@ -106,79 +114,54 @@ func (c *clockifyClient) parseEntries(fetchedEntries []FetchEntry, tagsAsTasksRe
 		}
 
 		if c.TagsAsTasks && len(entry.Tags) > 0 {
-			pageEntries := worklogEntry.SplitByTagsAsTasks(entry.Description, tagsAsTasksRegex, entry.Tags)
+			pageEntries := worklogEntry.SplitByTagsAsTasks(entry.Description, c.tagsAsTasksRegex, entry.Tags)
 			entries = append(entries, pageEntries...)
 		} else {
 			entries = append(entries, worklogEntry)
 		}
 	}
 
-	return entries
+	return entries, nil
 }
 
-func (c *clockifyClient) fetchEntries(ctx context.Context, searchURL string) ([]FetchEntry, error) {
+func (c *clockifyClient) fetchEntries(ctx context.Context, reqURL string) (interface{}, *client.PaginatedFetchResponse, error) {
 	resp, err := c.Call(ctx, &client.HTTPRequestOpts{
 		Method:  http.MethodGet,
-		Url:     searchURL,
+		Url:     reqURL,
 		Auth:    c.authenticator,
 		Timeout: c.Timeout,
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
 	var fetchedEntries []FetchEntry
 	if err = json.Unmarshal(resp, &fetchedEntries); err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
-	return fetchedEntries, nil
+	return fetchedEntries, &client.PaginatedFetchResponse{}, err
 }
 
 func (c *clockifyClient) FetchEntries(ctx context.Context, opts *client.FetchOpts) (worklog.Entries, error) {
-	var err error
-	var entries worklog.Entries
-	currentPage := 1
-	pageSize := 100
+	fetchURL, err := c.URL(fmt.Sprintf(PathWorklog, c.workspace, opts.User), map[string]string{
+		"start":       utils.DateFormatRFC3339UTC.Format(opts.Start.Local()),
+		"end":         utils.DateFormatRFC3339UTC.Format(opts.End.Local()),
+		"hydrated":    strconv.FormatBool(true),
+		"in-progress": strconv.FormatBool(false),
+	})
 
-	var tagsAsTasksRegex *regexp.Regexp
-	if c.TagsAsTasks {
-		tagsAsTasksRegex, err = regexp.Compile(c.TagsAsTasksRegex)
-		if err != nil {
-			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-		}
+	if err != nil {
+		return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
-	// Naive pagination as the API does not return the number of total entries
-	for currentPage*pageSize < MaxPageLength {
-		searchURL, err := c.URL(fmt.Sprintf(PathWorklog, c.workspace, opts.User), map[string]string{
-			"start":       utils.DateFormatRFC3339UTC.Format(opts.Start.Local()),
-			"end":         utils.DateFormatRFC3339UTC.Format(opts.End.Local()),
-			"page":        strconv.Itoa(currentPage),
-			"page-size":   strconv.Itoa(pageSize),
-			"hydrated":    strconv.FormatBool(true),
-			"in-progress": strconv.FormatBool(false),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-		}
-
-		fetchedEntries, err := c.fetchEntries(ctx, searchURL)
-		if err != nil {
-			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-		}
-
-		// The API returned no entries, meaning no entries left
-		if len(fetchedEntries) == 0 {
-			break
-		}
-
-		entries = append(entries, c.parseEntries(fetchedEntries, tagsAsTasksRegex)...)
-		currentPage++
-	}
-
-	return entries, nil
+	return c.PaginatedFetch(ctx, &client.PaginatedFetchOpts{
+		URL:           fetchURL,
+		PageSizeParam: "page-size",
+		FetchFunc:     c.fetchEntries,
+		ParseFunc:     c.parseEntries,
+	})
 }
 
 // NewFetcher returns a new Clockify client for fetching entries.
@@ -193,10 +176,21 @@ func NewFetcher(opts *ClientOpts) (client.Fetcher, error) {
 		return nil, err
 	}
 
+	// TODO: Remove this after opt.TagsAsTasksRegex is refactored
+	var tagsAsTasksRegex *regexp.Regexp
+	if opts.TagsAsTasks {
+		tagsAsTasksRegex, err = regexp.Compile(opts.TagsAsTasksRegex)
+		if err != nil {
+			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
+		}
+	}
+
 	return &clockifyClient{
 		authenticator:  authenticator,
 		HTTPClient:     &client.HTTPClient{BaseURL: baseURL},
 		BaseClientOpts: &opts.BaseClientOpts,
 		workspace:      opts.Workspace,
+		// TODO: Remove this after opt.TagsAsTasksRegex is refactored
+		tagsAsTasksRegex: tagsAsTasksRegex,
 	}, nil
 }

--- a/internal/pkg/client/clockify/clockify_test.go
+++ b/internal/pkg/client/clockify/clockify_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -188,6 +189,9 @@ func TestClockifyClient_FetchEntries(t *testing.T) {
 	defer mockServer.Close()
 
 	clockifyClient, err := clockify.NewFetcher(&clockify.ClientOpts{
+		BaseClientOpts: client.BaseClientOpts{
+			Timeout: client.DefaultRequestTimeout,
+		},
 		TokenAuth: client.TokenAuth{
 			Header: "X-Api-Key",
 			Token:  "t-o-k-e-n",
@@ -354,7 +358,8 @@ func TestClockifyClient_FetchEntries_TasksAsTags(t *testing.T) {
 	clockifyClient, err := clockify.NewFetcher(&clockify.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
 			TagsAsTasks:      true,
-			TagsAsTasksRegex: `^TASK\-\d+$`,
+			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
+			Timeout:          client.DefaultRequestTimeout,
 		},
 		TokenAuth: client.TokenAuth{
 			Header: "X-Api-Key",

--- a/internal/pkg/client/fetcher.go
+++ b/internal/pkg/client/fetcher.go
@@ -13,10 +13,10 @@ const (
 	// The minimum page sizes can be different per client, but the 50 items per
 	// page is usually supported everywhere.
 	DefaultPageSize int = 50
-	// DefaultMaxPageSize used by paginated fetchers setting the maximum entries
-	// per page. The maximum page sizes can be different per client, but the
-	// 250 items per page is usually supported everywhere.
-	DefaultMaxPageSize int = 250
+	// DefaultPageSizeParam used by paginated fetchers setting page size parameter.
+	DefaultPageSizeParam string = "per_page"
+	// DefaultPageParam used by paginated fetchers setting the page parameter.
+	DefaultPageParam string = "page"
 )
 
 var (
@@ -39,4 +39,22 @@ type Fetcher interface {
 	// If the fetching resulted in an error, the list of worklog entries will be
 	// nil and an error will return.
 	FetchEntries(ctx context.Context, opts *FetchOpts) (worklog.Entries, error)
+}
+
+type PaginatedFetchResponse struct {
+	EntriesPerPage int
+	TotalEntries   int
+}
+
+type PaginatedFetchFunc = func(context.Context, string) (interface{}, *PaginatedFetchResponse, error)
+type PaginatedParseFunc = func(interface{}) (worklog.Entries, error)
+
+type PaginatedFetchOpts struct {
+	URL           string
+	PageSize      int
+	PageSizeParam string
+	PageParam     string
+
+	FetchFunc PaginatedFetchFunc
+	ParseFunc PaginatedParseFunc
 }

--- a/internal/pkg/client/tempo/tempo_test.go
+++ b/internal/pkg/client/tempo/tempo_test.go
@@ -242,6 +242,9 @@ func TestTempoClient_FetchEntries(t *testing.T) {
 	defer mockServer.Close()
 
 	tempoClient, err := tempo.NewFetcher(&tempo.ClientOpts{
+		BaseClientOpts: client.BaseClientOpts{
+			Timeout: client.DefaultRequestTimeout,
+		},
 		BasicAuth: client.BasicAuth{
 			Username: clientUsername,
 			Password: clientPassword,
@@ -337,6 +340,9 @@ func TestTempoClient_UploadEntries(t *testing.T) {
 	defer mockServer.Close()
 
 	tempoClient, err := tempo.NewUploader(&tempo.ClientOpts{
+		BaseClientOpts: client.BaseClientOpts{
+			Timeout: client.DefaultRequestTimeout,
+		},
 		BasicAuth: client.BasicAuth{
 			Username: clientUsername,
 			Password: clientPassword,
@@ -431,6 +437,9 @@ func TestTempoClient_UploadEntries_TreatDurationAsBilled(t *testing.T) {
 	defer mockServer.Close()
 
 	tempoClient, err := tempo.NewUploader(&tempo.ClientOpts{
+		BaseClientOpts: client.BaseClientOpts{
+			Timeout: client.DefaultRequestTimeout,
+		},
 		BasicAuth: client.BasicAuth{
 			Username: clientUsername,
 			Password: clientPassword,
@@ -585,6 +594,9 @@ func TestTempoClient_UploadEntries_RoundToClosestMinute(t *testing.T) {
 	defer mockServer.Close()
 
 	tempoClient, err := tempo.NewUploader(&tempo.ClientOpts{
+		BaseClientOpts: client.BaseClientOpts{
+			Timeout: client.DefaultRequestTimeout,
+		},
 		BasicAuth: client.BasicAuth{
 			Username: clientUsername,
 			Password: clientPassword,

--- a/internal/pkg/client/timewarrior/timewarrior.go
+++ b/internal/pkg/client/timewarrior/timewarrior.go
@@ -38,10 +38,9 @@ type ClientOpts struct {
 type timewarriorClient struct {
 	*client.BaseClientOpts
 	*client.CLIClient
-	clientTagRegex   *regexp.Regexp
-	projectTagRegex  *regexp.Regexp
-	tagsAsTasksRegex *regexp.Regexp
-	unbillableTag    string
+	clientTagRegex  *regexp.Regexp
+	projectTagRegex *regexp.Regexp
+	unbillableTag   string
 }
 
 func (c *timewarriorClient) parseEntry(entry FetchEntry) (worklog.Entries, error) {
@@ -79,7 +78,7 @@ func (c *timewarriorClient) parseEntry(entry FetchEntry) (worklog.Entries, error
 				ID:   tag,
 				Name: tag,
 			}
-		} else if c.tagsAsTasksRegex.String() != "" && c.tagsAsTasksRegex.MatchString(tag) {
+		} else if c.TagsAsTasksRegex.String() != "" && c.TagsAsTasksRegex.MatchString(tag) {
 			worklogEntry.Task = worklog.IDNameField{
 				ID:   tag,
 				Name: tag,
@@ -104,7 +103,7 @@ func (c *timewarriorClient) parseEntry(entry FetchEntry) (worklog.Entries, error
 			})
 		}
 
-		splitEntries := worklogEntry.SplitByTagsAsTasks(worklogEntry.Summary, c.tagsAsTasksRegex, tags)
+		splitEntries := worklogEntry.SplitByTagsAsTasks(worklogEntry.Summary, c.TagsAsTasksRegex, tags)
 		entries = append(entries, splitEntries...)
 	} else {
 		entries = append(entries, worklogEntry)
@@ -172,17 +171,11 @@ func NewFetcher(opts *ClientOpts) (client.Fetcher, error) {
 		return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
-	tagsAsTasksRegex, err := regexp.Compile(opts.TagsAsTasksRegex)
-	if err != nil {
-		return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-	}
-
 	return &timewarriorClient{
-		BaseClientOpts:   &opts.BaseClientOpts,
-		CLIClient:        &opts.CLIClient,
-		unbillableTag:    opts.UnbillableTag,
-		clientTagRegex:   clientTagRegex,
-		projectTagRegex:  projectTagRegex,
-		tagsAsTasksRegex: tagsAsTasksRegex,
+		BaseClientOpts:  &opts.BaseClientOpts,
+		CLIClient:       &opts.CLIClient,
+		unbillableTag:   opts.UnbillableTag,
+		clientTagRegex:  clientTagRegex,
+		projectTagRegex: projectTagRegex,
 	}, nil
 }

--- a/internal/pkg/client/timewarrior/timewarrior_test.go
+++ b/internal/pkg/client/timewarrior/timewarrior_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -119,7 +120,10 @@ func TestTimewarriorClient_FetchEntries(t *testing.T) {
 	}
 
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
-		BaseClientOpts: client.BaseClientOpts{},
+		BaseClientOpts: client.BaseClientOpts{
+			TagsAsTasksRegex: regexp.MustCompile(""),
+			Timeout:          client.DefaultRequestTimeout,
+		},
 		CLIClient: client.CLIClient{
 			Command:            "timewarrior-command",
 			CommandArguments:   []string{},
@@ -215,7 +219,8 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasksRegex_NoSplit(t *testing.T) {
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
 			TagsAsTasks:      false,
-			TagsAsTasksRegex: `^TASK\-\d+$`,
+			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
+			Timeout:          client.DefaultRequestTimeout,
 		},
 		CLIClient: client.CLIClient{
 			Command:            "timewarrior-command",
@@ -331,7 +336,8 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasks(t *testing.T) {
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
 			TagsAsTasks:      true,
-			TagsAsTasksRegex: `^TASK\-\d+$`,
+			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
+			Timeout:          client.DefaultRequestTimeout,
 		},
 		CLIClient: client.CLIClient{
 			Command:            "timewarrior-command",

--- a/internal/pkg/client/toggl/toggl.go
+++ b/internal/pkg/client/toggl/toggl.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -57,9 +56,6 @@ type togglClient struct {
 	*client.HTTPClient
 	authenticator client.Authenticator
 	workspace     int
-
-	// TODO: opts.TagsAsTasksRegex should be a regexp to avoid this
-	tagsAsTasksRegex *regexp.Regexp
 }
 
 func (c *togglClient) parseEntries(rawEntries interface{}) (worklog.Entries, error) {
@@ -108,7 +104,7 @@ func (c *togglClient) parseEntries(rawEntries interface{}) (worklog.Entries, err
 				})
 			}
 
-			splitEntries := entry.SplitByTagsAsTasks(entry.Summary, c.tagsAsTasksRegex, tags)
+			splitEntries := entry.SplitByTagsAsTasks(entry.Summary, c.TagsAsTasksRegex, tags)
 			entries = append(entries, splitEntries...)
 		} else {
 			entries = append(entries, entry)
@@ -180,15 +176,6 @@ func NewFetcher(opts *ClientOpts) (client.Fetcher, error) {
 		return nil, err
 	}
 
-	// TODO: Remove this after opt.TagsAsTasksRegex is refactored
-	var tagsAsTasksRegex *regexp.Regexp
-	if opts.TagsAsTasks {
-		tagsAsTasksRegex, err = regexp.Compile(opts.TagsAsTasksRegex)
-		if err != nil {
-			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-		}
-	}
-
 	return &togglClient{
 		authenticator: authenticator,
 		HTTPClient: &client.HTTPClient{
@@ -196,7 +183,5 @@ func NewFetcher(opts *ClientOpts) (client.Fetcher, error) {
 		},
 		BaseClientOpts: &opts.BaseClientOpts,
 		workspace:      opts.Workspace,
-		// TODO: Remove this after opt.TagsAsTasksRegex is refactored
-		tagsAsTasksRegex: tagsAsTasksRegex,
 	}, nil
 }

--- a/internal/pkg/client/toggl/toggl.go
+++ b/internal/pkg/client/toggl/toggl.go
@@ -36,9 +36,9 @@ type FetchEntry struct {
 	TaskID      int       `json:"tid"`
 }
 
-// PaginatedResponse represents the response of Toggl Track report APIs.
+// FetchResponse represents the response of Toggl Track report APIs.
 // The response would have more fields, but those are not relevant for us.
-type PaginatedResponse struct {
+type FetchResponse struct {
 	TotalCount int          `json:"total_count"`
 	PerPage    int          `json:"per_page"`
 	Data       []FetchEntry `json:"data"`
@@ -57,10 +57,18 @@ type togglClient struct {
 	*client.HTTPClient
 	authenticator client.Authenticator
 	workspace     int
+
+	// TODO: opts.TagsAsTasksRegex should be a regexp to avoid this
+	tagsAsTasksRegex *regexp.Regexp
 }
 
-func (c *togglClient) parseEntries(fetchedEntries []FetchEntry, tagsAsTasksRegex *regexp.Regexp) (worklog.Entries, error) {
+func (c *togglClient) parseEntries(rawEntries interface{}) (worklog.Entries, error) {
 	var entries worklog.Entries
+
+	fetchedEntries, ok := rawEntries.([]FetchEntry)
+	if !ok {
+		return nil, fmt.Errorf("%v: %s", client.ErrFetchEntries, "cannot parse returned entries")
+	}
 
 	for _, fetchedEntry := range fetchedEntries {
 		billableDuration := time.Millisecond * time.Duration(fetchedEntry.Duration)
@@ -100,7 +108,7 @@ func (c *togglClient) parseEntries(fetchedEntries []FetchEntry, tagsAsTasksRegex
 				})
 			}
 
-			splitEntries := entry.SplitByTagsAsTasks(entry.Summary, tagsAsTasksRegex, tags)
+			splitEntries := entry.SplitByTagsAsTasks(entry.Summary, c.tagsAsTasksRegex, tags)
 			entries = append(entries, splitEntries...)
 		} else {
 			entries = append(entries, entry)
@@ -110,7 +118,7 @@ func (c *togglClient) parseEntries(fetchedEntries []FetchEntry, tagsAsTasksRegex
 	return entries, nil
 }
 
-func (c *togglClient) fetchEntries(ctx context.Context, reqURL string, tagsAsTasksRegex *regexp.Regexp) (worklog.Entries, *PaginatedResponse, error) {
+func (c *togglClient) fetchEntries(ctx context.Context, reqURL string) (interface{}, *client.PaginatedFetchResponse, error) {
 	resp, err := c.Call(ctx, &client.HTTPRequestOpts{
 		Method:  http.MethodGet,
 		Url:     reqURL,
@@ -122,67 +130,42 @@ func (c *togglClient) fetchEntries(ctx context.Context, reqURL string, tagsAsTas
 		return nil, nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
-	var paginatedResponse PaginatedResponse
-	if err = json.Unmarshal(resp, &paginatedResponse); err != nil {
+	var fetchResponse FetchResponse
+	if err = json.Unmarshal(resp, &fetchResponse); err != nil {
 		return nil, nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
-	parsedEntries, err := c.parseEntries(paginatedResponse.Data, tagsAsTasksRegex)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
+	paginatedResponse := &client.PaginatedFetchResponse{
+		EntriesPerPage: fetchResponse.PerPage,
+		TotalEntries:   fetchResponse.TotalCount,
 	}
 
-	return parsedEntries, &paginatedResponse, err
+	return fetchResponse.Data, paginatedResponse, err
 }
 
 func (c *togglClient) FetchEntries(ctx context.Context, opts *client.FetchOpts) (worklog.Entries, error) {
-	var err error
-	var entries worklog.Entries
-	var tagsAsTasksRegex *regexp.Regexp
-
-	if c.TagsAsTasks {
-		tagsAsTasksRegex, err = regexp.Compile(c.TagsAsTasksRegex)
-		if err != nil {
-			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-		}
-	}
-
-	var pageSize int
-	currentPage := 1
-	paginationNeeded := true
-
 	userID, err := strconv.Atoi(strings.Split(opts.User, ",")[0])
 	if err != nil {
 		return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
-	for paginationNeeded {
-		searchURL, err := c.URL(PathWorklog, map[string]string{
-			"since":        utils.DateFormatISO8601.Format(opts.Start),
-			"until":        utils.DateFormatISO8601.Format(opts.End),
-			"page":         strconv.Itoa(currentPage),
-			"user_id":      strconv.Itoa(userID),
-			"workspace_id": strconv.Itoa(c.workspace),
-			"user_agent":   "github.com/gabor-boros/minutes",
-		})
+	fetchURL, err := c.URL(PathWorklog, map[string]string{
+		"since":        utils.DateFormatISO8601.Format(opts.Start),
+		"until":        utils.DateFormatISO8601.Format(opts.End),
+		"user_id":      strconv.Itoa(userID),
+		"workspace_id": strconv.Itoa(c.workspace),
+		"user_agent":   "github.com/gabor-boros/minutes",
+	})
 
-		if err != nil {
-			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-		}
-
-		parsedEntries, paginatedResponse, err := c.fetchEntries(ctx, searchURL, tagsAsTasksRegex)
-		if err != nil {
-			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
-		}
-
-		entries = append(entries, parsedEntries...)
-
-		pageSize = paginatedResponse.PerPage
-		paginationNeeded = (paginatedResponse.TotalCount - pageSize*currentPage) > 0
-		currentPage++
+	if err != nil {
+		return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
 	}
 
-	return entries, nil
+	return c.PaginatedFetch(ctx, &client.PaginatedFetchOpts{
+		URL:       fetchURL,
+		FetchFunc: c.fetchEntries,
+		ParseFunc: c.parseEntries,
+	})
 }
 
 // NewFetcher returns a new Toggl client for fetching entries.
@@ -197,10 +180,23 @@ func NewFetcher(opts *ClientOpts) (client.Fetcher, error) {
 		return nil, err
 	}
 
+	// TODO: Remove this after opt.TagsAsTasksRegex is refactored
+	var tagsAsTasksRegex *regexp.Regexp
+	if opts.TagsAsTasks {
+		tagsAsTasksRegex, err = regexp.Compile(opts.TagsAsTasksRegex)
+		if err != nil {
+			return nil, fmt.Errorf("%v: %v", client.ErrFetchEntries, err)
+		}
+	}
+
 	return &togglClient{
-		authenticator:  authenticator,
-		HTTPClient:     &client.HTTPClient{BaseURL: baseURL},
+		authenticator: authenticator,
+		HTTPClient: &client.HTTPClient{
+			BaseURL: baseURL,
+		},
 		BaseClientOpts: &opts.BaseClientOpts,
 		workspace:      opts.Workspace,
+		// TODO: Remove this after opt.TagsAsTasksRegex is refactored
+		tagsAsTasksRegex: tagsAsTasksRegex,
 	}, nil
 }

--- a/internal/pkg/client/toggl/toggl_test.go
+++ b/internal/pkg/client/toggl/toggl_test.go
@@ -24,7 +24,7 @@ type mockServerOpts struct {
 	StatusCode   int
 	Username     string
 	Password     string
-	ResponseData *toggl.PaginatedResponse
+	ResponseData *toggl.FetchResponse
 }
 
 func mockServer(t *testing.T, e *mockServerOpts) *httptest.Server {
@@ -106,6 +106,7 @@ func TestTogglClient_FetchEntries(t *testing.T) {
 		Path: toggl.PathWorklog,
 		QueryParams: url.Values{
 			"page":         {"1"},
+			"per_page":     {"50"},
 			"since":        {utils.DateFormatISO8601.Format(start)},
 			"until":        {utils.DateFormatISO8601.Format(end)},
 			"user_id":      {"987654321"},
@@ -116,7 +117,9 @@ func TestTogglClient_FetchEntries(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Username:   clientUsername,
 		Password:   clientPassword,
-		ResponseData: &toggl.PaginatedResponse{
+		ResponseData: &toggl.FetchResponse{
+			TotalCount: 2,
+			PerPage:    50,
 			Data: []toggl.FetchEntry{
 				{
 					Client:      "My Awesome Company",
@@ -240,6 +243,7 @@ func TestTogglClient_FetchEntries_TagsAsTasks(t *testing.T) {
 		Path: toggl.PathWorklog,
 		QueryParams: url.Values{
 			"page":         {"1"},
+			"per_page":     {"50"},
 			"since":        {utils.DateFormatISO8601.Format(start)},
 			"until":        {utils.DateFormatISO8601.Format(end)},
 			"user_id":      {"987654321"},
@@ -250,7 +254,9 @@ func TestTogglClient_FetchEntries_TagsAsTasks(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Username:   clientUsername,
 		Password:   clientPassword,
-		ResponseData: &toggl.PaginatedResponse{
+		ResponseData: &toggl.FetchResponse{
+			TotalCount: 2,
+			PerPage:    50,
 			Data: []toggl.FetchEntry{
 				{
 					Client:      "My Awesome Company",

--- a/internal/pkg/client/toggl/toggl_test.go
+++ b/internal/pkg/client/toggl/toggl_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -153,6 +154,9 @@ func TestTogglClient_FetchEntries(t *testing.T) {
 	defer mockServer.Close()
 
 	togglClient, err := toggl.NewFetcher(&toggl.ClientOpts{
+		BaseClientOpts: client.BaseClientOpts{
+			Timeout: client.DefaultRequestTimeout,
+		},
 		BasicAuth: client.BasicAuth{
 			Username: clientUsername,
 			Password: clientPassword,
@@ -294,7 +298,8 @@ func TestTogglClient_FetchEntries_TagsAsTasks(t *testing.T) {
 	togglClient, err := toggl.NewFetcher(&toggl.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
 			TagsAsTasks:      true,
-			TagsAsTasksRegex: `^CPT\-\w+$`,
+			TagsAsTasksRegex: regexp.MustCompile(`^CPT-\w+$`),
+			Timeout:          client.DefaultRequestTimeout,
 		},
 		BasicAuth: client.BasicAuth{
 			Username: clientUsername,


### PR DESCRIPTION
## Description

This PR unifies the paginated API calls and refactor how TagsAsTasks regexp parsed and passed around in the code.

## Supporting information

N/A

### Dependencies

N/A

### Screenshots

N/A

## Testing instructions

1. Call minutes using your favorite source and target

## Other information

N/A

## Checklist

- ~~Documentation is updated~~ -- Not relevant
- [x] Pull request is rebased onto main
- [x] Commit history is clean
