### PR TITLE
Rework tag parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+**Documentation**
+
+- Fix comment wording ([cb3b3bb](https://github.com/gabor-boros/minutes/commit/cb3b3bb9763bdb6c68d5e93d5f7f16de0605abfe))
+
+**Refactor**
+
+- Remove tags-as-tasks flag ([8ea8769](https://github.com/gabor-boros/minutes/commit/8ea87697a14c59070d149bcca0823c2cc69228c7))
+- Move tags-as-tasks in-house to FetchOpts ([6caa95a](https://github.com/gabor-boros/minutes/commit/6caa95a91e4b0573057868563d19570e90383659))
+- Unify how regex is checked ([0c393c5](https://github.com/gabor-boros/minutes/commit/0c393c586ae1af8298f4d207f7459776efb24bfc))
+
+**Testing**
+
+- Use `ElementsMatch` over `Equal` ([841e0df](https://github.com/gabor-boros/minutes/commit/841e0df9a0ccd4a6b6067b7cff494b89f4c7cbe5))
+
 ## [0.2.3] - 2021-11-08
 
 **Build**

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Flags:
       --start string                           set the start date (defaults to 00:00:00)
       --table-hide-column strings              hide table column [summary project client start end]
       --table-sort-by strings                  sort table by column [task summary project client start end billable unbillable] (default [start,project,task,summary])
-      --tags-as-tasks                          treat tags matching the value of tags-as-tasks-regex as tasks
       --tags-as-tasks-regex string             regex of the task pattern
   -t, --target string                          set the target of the sync [tempo]
       --target-user string                     set the source user ID
@@ -130,7 +129,7 @@ $ minutes --date-format "2006-01-02" --start "2021-10-07" --end "2021-10-08"
 
 ```shell
 # Specify how a tag should look like to be considered as a task
-$ minutes --tags-as-tasks --tags-as-tasks-regex '[A-Z]{2,7}-\d{1,6}'
+$ minutes --tags-as-tasks-regex '[A-Z]{2,7}-\d{1,6}'
 ```
 
 #### Minute based rounding
@@ -161,7 +160,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 round-to-closest-minute = true
 force-billed-duration = true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,7 +127,6 @@ func initCommonFlags() {
 	rootCmd.Flags().StringSliceP("table-sort-by", "", []string{utils.ColumnStart, utils.ColumnProject, utils.ColumnTask, utils.ColumnSummary}, fmt.Sprintf("sort table by column %v", utils.Columns))
 	rootCmd.Flags().StringSliceP("table-hide-column", "", []string{}, fmt.Sprintf("hide table column %v", utils.HideableColumns))
 
-	rootCmd.Flags().BoolP("tags-as-tasks", "", false, "treat tags matching the value of tags-as-tasks-regex as tasks")
 	rootCmd.Flags().StringP("tags-as-tasks-regex", "", "", "regex of the task pattern")
 
 	rootCmd.Flags().BoolP("round-to-closest-minute", "", false, "round time to closest minute")
@@ -196,16 +195,9 @@ func validateFlags() {
 		cobra.CheckErr(fmt.Sprintf("\"%s\" is not part of the supported targets %v\n", target, targets))
 	}
 
-	if viper.GetBool("tags-as-tasks") {
-		tasksAsTagsRegex := viper.GetString("tags-as-tasks-regex")
-
-		if tasksAsTagsRegex == "" {
-			cobra.CheckErr("tags-as-tasks-regex cannot be empty if tags-as-tasks is set")
-		}
-
-		_, err = regexp.Compile(tasksAsTagsRegex)
-		cobra.CheckErr(err)
-	}
+	tagsAsTasksRegex := viper.GetString("tags-as-tasks-regex")
+	_, err = regexp.Compile(tagsAsTasksRegex)
+	cobra.CheckErr(err)
 
 	for _, sortBy := range viper.GetStringSlice("table-sort-by") {
 		column := sortBy
@@ -261,7 +253,6 @@ func getFetcher() (client.Fetcher, error) {
 	case "clockify":
 		return clockify.NewFetcher(&clockify.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
 				TagsAsTasksRegex: tagsAsTasksRegex,
 				Timeout:          client.DefaultRequestTimeout,
 			},
@@ -275,7 +266,6 @@ func getFetcher() (client.Fetcher, error) {
 	case "harvest":
 		return harvest.NewFetcher(&harvest.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
 				TagsAsTasksRegex: tagsAsTasksRegex,
 				Timeout:          client.DefaultRequestTimeout,
 			},
@@ -289,7 +279,6 @@ func getFetcher() (client.Fetcher, error) {
 	case "tempo":
 		return tempo.NewFetcher(&tempo.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
 				TagsAsTasksRegex: tagsAsTasksRegex,
 				Timeout:          client.DefaultRequestTimeout,
 			},
@@ -302,7 +291,6 @@ func getFetcher() (client.Fetcher, error) {
 	case "timewarrior":
 		return timewarrior.NewFetcher(&timewarrior.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
 				TagsAsTasksRegex: tagsAsTasksRegex,
 				Timeout:          client.DefaultRequestTimeout,
 			},
@@ -318,7 +306,6 @@ func getFetcher() (client.Fetcher, error) {
 	case "toggl":
 		return toggl.NewFetcher(&toggl.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasks:      viper.GetBool("tags-as-tasks"),
 				TagsAsTasksRegex: tagsAsTasksRegex,
 				Timeout:          client.DefaultRequestTimeout,
 			},
@@ -339,8 +326,7 @@ func getUploader() (client.Uploader, error) {
 	case "tempo":
 		return tempo.NewUploader(&tempo.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasks: viper.GetBool("tags-as-tasks"),
-				Timeout:     client.DefaultRequestTimeout,
+				Timeout: client.DefaultRequestTimeout,
 			},
 			BasicAuth: client.BasicAuth{
 				Username: viper.GetString("tempo-username"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -244,17 +244,12 @@ func validateFlags() {
 }
 
 func getFetcher() (client.Fetcher, error) {
-	tagsAsTasksRegex, err := regexp.Compile(viper.GetString("tags-as-tasks-regex"))
-	if err != nil {
-		return nil, err
-	}
 
 	switch viper.GetString("source") {
 	case "clockify":
 		return clockify.NewFetcher(&clockify.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasksRegex: tagsAsTasksRegex,
-				Timeout:          client.DefaultRequestTimeout,
+				Timeout: client.DefaultRequestTimeout,
 			},
 			TokenAuth: client.TokenAuth{
 				Header: "X-Api-Key",
@@ -266,8 +261,7 @@ func getFetcher() (client.Fetcher, error) {
 	case "harvest":
 		return harvest.NewFetcher(&harvest.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasksRegex: tagsAsTasksRegex,
-				Timeout:          client.DefaultRequestTimeout,
+				Timeout: client.DefaultRequestTimeout,
 			},
 			TokenAuth: client.TokenAuth{
 				TokenName: "Bearer",
@@ -279,8 +273,7 @@ func getFetcher() (client.Fetcher, error) {
 	case "tempo":
 		return tempo.NewFetcher(&tempo.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasksRegex: tagsAsTasksRegex,
-				Timeout:          client.DefaultRequestTimeout,
+				Timeout: client.DefaultRequestTimeout,
 			},
 			BasicAuth: client.BasicAuth{
 				Username: viper.GetString("tempo-username"),
@@ -291,8 +284,7 @@ func getFetcher() (client.Fetcher, error) {
 	case "timewarrior":
 		return timewarrior.NewFetcher(&timewarrior.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasksRegex: tagsAsTasksRegex,
-				Timeout:          client.DefaultRequestTimeout,
+				Timeout: client.DefaultRequestTimeout,
 			},
 			CLIClient: client.CLIClient{
 				Command:            viper.GetString("timewarrior-command"),
@@ -306,8 +298,7 @@ func getFetcher() (client.Fetcher, error) {
 	case "toggl":
 		return toggl.NewFetcher(&toggl.ClientOpts{
 			BaseClientOpts: client.BaseClientOpts{
-				TagsAsTasksRegex: tagsAsTasksRegex,
-				Timeout:          client.DefaultRequestTimeout,
+				Timeout: client.DefaultRequestTimeout,
 			},
 			BasicAuth: client.BasicAuth{
 				Username: viper.GetString("toggl-api-key"),
@@ -373,10 +364,14 @@ func runRootCmd(_ *cobra.Command, _ []string) {
 	uploader, err := getUploader()
 	cobra.CheckErr(err)
 
+	tagsAsTasksRegex, err := regexp.Compile(viper.GetString("tags-as-tasks-regex"))
+	cobra.CheckErr(err)
+
 	entries, err := fetcher.FetchEntries(context.Background(), &client.FetchOpts{
-		End:   end,
-		Start: start,
-		User:  viper.GetString("source-user"),
+		End:              end,
+		Start:            start,
+		User:             viper.GetString("source-user"),
+		TagsAsTasksRegex: tagsAsTasksRegex,
 	})
 	cobra.CheckErr(err)
 

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -40,17 +40,8 @@ var (
 // When a client needs other options as well, it composes a new set of options
 // using BaseClientOpts.
 type BaseClientOpts struct {
-	// TagsAsTasks defines to use tag names to determine the task.
-	// Using TagsAsTasks can be useful if the user's workflow involves
-	// splitting activity across multiple tasks, or when the user has no option
-	// to set multiple tasks for a single activity.
-	//
-	// This option must be used in conjunction with TagsAsTasksRegex option.
-	TagsAsTasks bool
 	// TagsAsTasksRegex sets the regular expression used for extracting tasks
 	// from the list of tags.
-	//
-	// This option must be used in conjunction with TagsAsTasks option.
 	TagsAsTasksRegex *regexp.Regexp
 	// Timeout sets the timeout for the client to execute a request.
 	// In the case of HTTP clients, the timeout is applied on the HTTP request,

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -12,7 +12,6 @@ import (
 	netURL "net/url"
 	"os/exec"
 	"reflect"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -40,9 +39,6 @@ var (
 // When a client needs other options as well, it composes a new set of options
 // using BaseClientOpts.
 type BaseClientOpts struct {
-	// TagsAsTasksRegex sets the regular expression used for extracting tasks
-	// from the list of tags.
-	TagsAsTasksRegex *regexp.Regexp
 	// Timeout sets the timeout for the client to execute a request.
 	// In the case of HTTP clients, the timeout is applied on the HTTP request,
 	// while in the case of CLI based clients it will be applied on the command
@@ -243,7 +239,7 @@ func (c *HTTPClient) PaginatedFetch(ctx context.Context, opts *PaginatedFetchOpt
 			break
 		}
 
-		parsedEntries, err := opts.ParseFunc(rawEntries)
+		parsedEntries, err := opts.ParseFunc(rawEntries, opts.BaseFetchOpts)
 		if err != nil {
 			return nil, fmt.Errorf("%v: %v", ErrFetchEntries, err)
 		}

--- a/internal/pkg/client/clockify/clockify.go
+++ b/internal/pkg/client/clockify/clockify.go
@@ -107,7 +107,7 @@ func (c *clockifyClient) parseEntries(rawEntries interface{}, opts *client.Fetch
 			UnbillableDuration: unbillableDuration,
 		}
 
-		if opts.TagsAsTasksRegex != nil && opts.TagsAsTasksRegex.String() != "" && len(entry.Tags) > 0 {
+		if utils.IsRegexSet(opts.TagsAsTasksRegex) && len(entry.Tags) > 0 {
 			pageEntries := worklogEntry.SplitByTagsAsTasks(entry.Description, opts.TagsAsTasksRegex, entry.Tags)
 			entries = append(entries, pageEntries...)
 		} else {

--- a/internal/pkg/client/clockify/clockify.go
+++ b/internal/pkg/client/clockify/clockify.go
@@ -107,7 +107,7 @@ func (c *clockifyClient) parseEntries(rawEntries interface{}) (worklog.Entries, 
 			UnbillableDuration: unbillableDuration,
 		}
 
-		if c.TagsAsTasks && len(entry.Tags) > 0 {
+		if c.TagsAsTasksRegex != nil && c.TagsAsTasksRegex.String() != "" && len(entry.Tags) > 0 {
 			pageEntries := worklogEntry.SplitByTagsAsTasks(entry.Description, c.TagsAsTasksRegex, entry.Tags)
 			entries = append(entries, pageEntries...)
 		} else {

--- a/internal/pkg/client/clockify/clockify.go
+++ b/internal/pkg/client/clockify/clockify.go
@@ -70,7 +70,7 @@ type clockifyClient struct {
 	workspace     string
 }
 
-func (c *clockifyClient) parseEntries(rawEntries interface{}) (worklog.Entries, error) {
+func (c *clockifyClient) parseEntries(rawEntries interface{}, opts *client.FetchOpts) (worklog.Entries, error) {
 	var entries worklog.Entries
 
 	fetchedEntries, ok := rawEntries.([]FetchEntry)
@@ -107,8 +107,8 @@ func (c *clockifyClient) parseEntries(rawEntries interface{}) (worklog.Entries, 
 			UnbillableDuration: unbillableDuration,
 		}
 
-		if c.TagsAsTasksRegex != nil && c.TagsAsTasksRegex.String() != "" && len(entry.Tags) > 0 {
-			pageEntries := worklogEntry.SplitByTagsAsTasks(entry.Description, c.TagsAsTasksRegex, entry.Tags)
+		if opts.TagsAsTasksRegex != nil && opts.TagsAsTasksRegex.String() != "" && len(entry.Tags) > 0 {
+			pageEntries := worklogEntry.SplitByTagsAsTasks(entry.Description, opts.TagsAsTasksRegex, entry.Tags)
 			entries = append(entries, pageEntries...)
 		} else {
 			entries = append(entries, worklogEntry)
@@ -151,6 +151,7 @@ func (c *clockifyClient) FetchEntries(ctx context.Context, opts *client.FetchOpt
 	}
 
 	return c.PaginatedFetch(ctx, &client.PaginatedFetchOpts{
+		BaseFetchOpts: opts,
 		URL:           fetchURL,
 		PageSizeParam: "page-size",
 		FetchFunc:     c.fetchEntries,

--- a/internal/pkg/client/clockify/clockify_test.go
+++ b/internal/pkg/client/clockify/clockify_test.go
@@ -357,8 +357,7 @@ func TestClockifyClient_FetchEntries_TagsAsTasks(t *testing.T) {
 
 	clockifyClient, err := clockify.NewFetcher(&clockify.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
-			Timeout:          client.DefaultRequestTimeout,
+			Timeout: client.DefaultRequestTimeout,
 		},
 		TokenAuth: client.TokenAuth{
 			Header: "X-Api-Key",
@@ -371,9 +370,10 @@ func TestClockifyClient_FetchEntries_TagsAsTasks(t *testing.T) {
 	require.Nil(t, err)
 
 	entries, err := clockifyClient.FetchEntries(context.Background(), &client.FetchOpts{
-		User:  "steve-rogers",
-		Start: start,
-		End:   end,
+		User:             "steve-rogers",
+		Start:            start,
+		End:              end,
+		TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
 	})
 
 	require.Nil(t, err, "cannot fetch entries")

--- a/internal/pkg/client/clockify/clockify_test.go
+++ b/internal/pkg/client/clockify/clockify_test.go
@@ -212,7 +212,7 @@ func TestClockifyClient_FetchEntries(t *testing.T) {
 	require.ElementsMatch(t, expectedEntries, entries, "fetched entries are not matching")
 }
 
-func TestClockifyClient_FetchEntries_TasksAsTags(t *testing.T) {
+func TestClockifyClient_FetchEntries_TagsAsTasks(t *testing.T) {
 	start := time.Date(2021, 10, 2, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2021, 10, 2, 23, 59, 59, 0, time.UTC)
 	remainingCalls := 1
@@ -357,7 +357,6 @@ func TestClockifyClient_FetchEntries_TasksAsTags(t *testing.T) {
 
 	clockifyClient, err := clockify.NewFetcher(&clockify.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasks:      true,
 			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
 			Timeout:          client.DefaultRequestTimeout,
 		},

--- a/internal/pkg/client/fetcher.go
+++ b/internal/pkg/client/fetcher.go
@@ -35,9 +35,6 @@ type FetchOpts struct {
 
 	// TagsAsTasksRegex sets the regular expression used for extracting tasks
 	// from the list of tags.
-	//
-	// If both TagsAsTasksRegex and TagsInSummaryRegex are set, the tags will be
-	// merged.
 	TagsAsTasksRegex *regexp.Regexp
 }
 

--- a/internal/pkg/client/fetcher.go
+++ b/internal/pkg/client/fetcher.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"regexp"
 	"time"
 
 	"github.com/gabor-boros/minutes/internal/pkg/worklog"
@@ -31,6 +32,13 @@ type FetchOpts struct {
 	User  string
 	Start time.Time
 	End   time.Time
+
+	// TagsAsTasksRegex sets the regular expression used for extracting tasks
+	// from the list of tags.
+	//
+	// If both TagsAsTasksRegex and TagsInSummaryRegex are set, the tags will be
+	// merged.
+	TagsAsTasksRegex *regexp.Regexp
 }
 
 // Fetcher specifies the functions used to fetch worklog entries.
@@ -47,9 +55,11 @@ type PaginatedFetchResponse struct {
 }
 
 type PaginatedFetchFunc = func(context.Context, string) (interface{}, *PaginatedFetchResponse, error)
-type PaginatedParseFunc = func(interface{}) (worklog.Entries, error)
+type PaginatedParseFunc = func(interface{}, *FetchOpts) (worklog.Entries, error)
 
 type PaginatedFetchOpts struct {
+	BaseFetchOpts *FetchOpts
+
 	URL           string
 	PageSize      int
 	PageSizeParam string

--- a/internal/pkg/client/harvest/harvest.go
+++ b/internal/pkg/client/harvest/harvest.go
@@ -82,7 +82,7 @@ type harvestClient struct {
 	account       int
 }
 
-func (c *harvestClient) parseEntries(rawEntries interface{}) (worklog.Entries, error) {
+func (c *harvestClient) parseEntries(rawEntries interface{}, _ *client.FetchOpts) (worklog.Entries, error) {
 	var entries worklog.Entries
 
 	fetchedEntries, ok := rawEntries.([]FetchEntry)

--- a/internal/pkg/client/timewarrior/timewarrior.go
+++ b/internal/pkg/client/timewarrior/timewarrior.go
@@ -68,17 +68,17 @@ func (c *timewarriorClient) parseEntry(entry FetchEntry, opts *client.FetchOpts)
 		if tag == c.unbillableTag {
 			worklogEntry.UnbillableDuration = worklogEntry.BillableDuration
 			worklogEntry.BillableDuration = 0
-		} else if c.clientTagRegex.String() != "" && c.clientTagRegex.MatchString(tag) {
+		} else if utils.IsRegexSet(c.clientTagRegex) && c.clientTagRegex.MatchString(tag) {
 			worklogEntry.Client = worklog.IDNameField{
 				ID:   tag,
 				Name: tag,
 			}
-		} else if c.projectTagRegex.String() != "" && c.projectTagRegex.MatchString(tag) {
+		} else if utils.IsRegexSet(c.projectTagRegex) && c.projectTagRegex.MatchString(tag) {
 			worklogEntry.Project = worklog.IDNameField{
 				ID:   tag,
 				Name: tag,
 			}
-		} else if opts.TagsAsTasksRegex != nil && opts.TagsAsTasksRegex.String() != "" && opts.TagsAsTasksRegex.MatchString(tag) {
+		} else if utils.IsRegexSet(opts.TagsAsTasksRegex) && opts.TagsAsTasksRegex.MatchString(tag) {
 			worklogEntry.Task = worklog.IDNameField{
 				ID:   tag,
 				Name: tag,
@@ -94,7 +94,7 @@ func (c *timewarriorClient) parseEntry(entry FetchEntry, opts *client.FetchOpts)
 		}
 	}
 
-	if opts.TagsAsTasksRegex != nil && opts.TagsAsTasksRegex.String() != "" && len(entry.Tags) > 0 {
+	if utils.IsRegexSet(opts.TagsAsTasksRegex) && len(entry.Tags) > 0 {
 		var tags []worklog.IDNameField
 		for _, tag := range entry.Tags {
 			tags = append(tags, worklog.IDNameField{

--- a/internal/pkg/client/timewarrior/timewarrior.go
+++ b/internal/pkg/client/timewarrior/timewarrior.go
@@ -78,7 +78,7 @@ func (c *timewarriorClient) parseEntry(entry FetchEntry) (worklog.Entries, error
 				ID:   tag,
 				Name: tag,
 			}
-		} else if c.TagsAsTasksRegex.String() != "" && c.TagsAsTasksRegex.MatchString(tag) {
+		} else if c.TagsAsTasksRegex != nil && c.TagsAsTasksRegex.String() != "" && c.TagsAsTasksRegex.MatchString(tag) {
 			worklogEntry.Task = worklog.IDNameField{
 				ID:   tag,
 				Name: tag,
@@ -94,7 +94,7 @@ func (c *timewarriorClient) parseEntry(entry FetchEntry) (worklog.Entries, error
 		}
 	}
 
-	if c.TagsAsTasks && len(entry.Tags) > 0 {
+	if c.TagsAsTasksRegex != nil && c.TagsAsTasksRegex.String() != "" && len(entry.Tags) > 0 {
 		var tags []worklog.IDNameField
 		for _, tag := range entry.Tags {
 			tags = append(tags, worklog.IDNameField{

--- a/internal/pkg/client/timewarrior/timewarrior_test.go
+++ b/internal/pkg/client/timewarrior/timewarrior_test.go
@@ -153,7 +153,7 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasksRegex_NoSplit(t *testing.T) {
 	mockedStdout = `[
 		{"id":3,"start":"20211012T054408Z","end":"20211012T054420Z","tags":["TASK-123","project","otherclient"],"annotation":"working on timewarrior integration"},
 		{"id":2,"start":"20211012T054408Z","end":"20211012T054420Z","tags":["TASK-123","project","client","unbillable"],"annotation":"working unbilled"},
-		{"id":1,"start":"20211012T054408Z","end":"20211012T054420Z","tags":["TASK-123","TASK-456","project","client","unbillable"],"annotation":"working unbilled"}
+		{"id":1,"start":"20211012T054408Z","end":"20211012T054420Z","tags":["TASK-456","project","client","unbillable"],"annotation":"working unbilled"}
 	]`
 
 	expectedEntries := worklog.Entries{
@@ -218,7 +218,6 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasksRegex_NoSplit(t *testing.T) {
 
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasks:      false,
 			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
 			Timeout:          client.DefaultRequestTimeout,
 		},
@@ -240,7 +239,7 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasksRegex_NoSplit(t *testing.T) {
 	})
 
 	require.Nil(t, err, "cannot fetch entries")
-	require.ElementsMatch(t, expectedEntries, entries, "fetched entries are not matching")
+	require.Equal(t, expectedEntries, entries, "fetched entries are not matching")
 }
 
 func TestTimewarriorClient_FetchEntries_TagsAsTasks(t *testing.T) {
@@ -335,7 +334,6 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasks(t *testing.T) {
 
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasks:      true,
 			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
 			Timeout:          client.DefaultRequestTimeout,
 		},

--- a/internal/pkg/client/timewarrior/timewarrior_test.go
+++ b/internal/pkg/client/timewarrior/timewarrior_test.go
@@ -239,7 +239,7 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasksRegex_NoSplit(t *testing.T) {
 	})
 
 	require.Nil(t, err, "cannot fetch entries")
-	require.Equal(t, expectedEntries, entries, "fetched entries are not matching")
+	require.ElementsMatch(t, expectedEntries, entries, "fetched entries are not matching")
 }
 
 func TestTimewarriorClient_FetchEntries_TagsAsTasks(t *testing.T) {

--- a/internal/pkg/client/timewarrior/timewarrior_test.go
+++ b/internal/pkg/client/timewarrior/timewarrior_test.go
@@ -121,8 +121,7 @@ func TestTimewarriorClient_FetchEntries(t *testing.T) {
 
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasksRegex: regexp.MustCompile(""),
-			Timeout:          client.DefaultRequestTimeout,
+			Timeout: client.DefaultRequestTimeout,
 		},
 		CLIClient: client.CLIClient{
 			Command:            "timewarrior-command",
@@ -137,8 +136,9 @@ func TestTimewarriorClient_FetchEntries(t *testing.T) {
 	require.Nil(t, err)
 
 	entries, err := timewarriorClient.FetchEntries(context.Background(), &client.FetchOpts{
-		Start: start,
-		End:   end,
+		Start:            start,
+		End:              end,
+		TagsAsTasksRegex: regexp.MustCompile(""),
 	})
 
 	require.Nil(t, err, "cannot fetch entries")
@@ -218,8 +218,7 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasksRegex_NoSplit(t *testing.T) {
 
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
-			Timeout:          client.DefaultRequestTimeout,
+			Timeout: client.DefaultRequestTimeout,
 		},
 		CLIClient: client.CLIClient{
 			Command:            "timewarrior-command",
@@ -234,8 +233,9 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasksRegex_NoSplit(t *testing.T) {
 	require.Nil(t, err)
 
 	entries, err := timewarriorClient.FetchEntries(context.Background(), &client.FetchOpts{
-		Start: start,
-		End:   end,
+		Start:            start,
+		End:              end,
+		TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
 	})
 
 	require.Nil(t, err, "cannot fetch entries")
@@ -334,8 +334,7 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasks(t *testing.T) {
 
 	timewarriorClient, err := timewarrior.NewFetcher(&timewarrior.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
-			Timeout:          client.DefaultRequestTimeout,
+			Timeout: client.DefaultRequestTimeout,
 		},
 		CLIClient: client.CLIClient{
 			Command:            "timewarrior-command",
@@ -350,8 +349,9 @@ func TestTimewarriorClient_FetchEntries_TagsAsTasks(t *testing.T) {
 	require.Nil(t, err)
 
 	entries, err := timewarriorClient.FetchEntries(context.Background(), &client.FetchOpts{
-		Start: start,
-		End:   end,
+		Start:            start,
+		End:              end,
+		TagsAsTasksRegex: regexp.MustCompile(`^TASK-\d+$`),
 	})
 
 	require.Nil(t, err, "cannot fetch entries")

--- a/internal/pkg/client/toggl/toggl.go
+++ b/internal/pkg/client/toggl/toggl.go
@@ -94,7 +94,7 @@ func (c *togglClient) parseEntries(rawEntries interface{}, opts *client.FetchOpt
 			UnbillableDuration: unbillableDuration,
 		}
 
-		if opts.TagsAsTasksRegex != nil && opts.TagsAsTasksRegex.String() != "" && len(fetchedEntry.Tags) > 0 {
+		if utils.IsRegexSet(opts.TagsAsTasksRegex) && len(fetchedEntry.Tags) > 0 {
 			var tags []worklog.IDNameField
 			for _, tag := range fetchedEntry.Tags {
 				tags = append(tags, worklog.IDNameField{

--- a/internal/pkg/client/toggl/toggl.go
+++ b/internal/pkg/client/toggl/toggl.go
@@ -57,7 +57,7 @@ type togglClient struct {
 	workspace     int
 }
 
-func (c *togglClient) parseEntries(rawEntries interface{}) (worklog.Entries, error) {
+func (c *togglClient) parseEntries(rawEntries interface{}, opts *client.FetchOpts) (worklog.Entries, error) {
 	var entries worklog.Entries
 
 	fetchedEntries, ok := rawEntries.([]FetchEntry)
@@ -94,7 +94,7 @@ func (c *togglClient) parseEntries(rawEntries interface{}) (worklog.Entries, err
 			UnbillableDuration: unbillableDuration,
 		}
 
-		if c.TagsAsTasksRegex != nil && c.TagsAsTasksRegex.String() != "" && len(fetchedEntry.Tags) > 0 {
+		if opts.TagsAsTasksRegex != nil && opts.TagsAsTasksRegex.String() != "" && len(fetchedEntry.Tags) > 0 {
 			var tags []worklog.IDNameField
 			for _, tag := range fetchedEntry.Tags {
 				tags = append(tags, worklog.IDNameField{
@@ -103,7 +103,7 @@ func (c *togglClient) parseEntries(rawEntries interface{}) (worklog.Entries, err
 				})
 			}
 
-			splitEntries := entry.SplitByTagsAsTasks(entry.Summary, c.TagsAsTasksRegex, tags)
+			splitEntries := entry.SplitByTagsAsTasks(entry.Summary, opts.TagsAsTasksRegex, tags)
 			entries = append(entries, splitEntries...)
 		} else {
 			entries = append(entries, entry)
@@ -152,9 +152,10 @@ func (c *togglClient) FetchEntries(ctx context.Context, opts *client.FetchOpts) 
 	}
 
 	return c.PaginatedFetch(ctx, &client.PaginatedFetchOpts{
-		URL:       fetchURL,
-		FetchFunc: c.fetchEntries,
-		ParseFunc: c.parseEntries,
+		BaseFetchOpts: opts,
+		URL:           fetchURL,
+		FetchFunc:     c.fetchEntries,
+		ParseFunc:     c.parseEntries,
 	})
 }
 

--- a/internal/pkg/client/toggl/toggl.go
+++ b/internal/pkg/client/toggl/toggl.go
@@ -94,7 +94,7 @@ func (c *togglClient) parseEntries(rawEntries interface{}) (worklog.Entries, err
 			UnbillableDuration: unbillableDuration,
 		}
 
-		if c.TagsAsTasks && len(fetchedEntry.Tags) > 0 {
+		if c.TagsAsTasksRegex != nil && c.TagsAsTasksRegex.String() != "" && len(fetchedEntry.Tags) > 0 {
 			var tags []worklog.IDNameField
 			for _, tag := range fetchedEntry.Tags {
 				tags = append(tags, worklog.IDNameField{

--- a/internal/pkg/client/toggl/toggl_test.go
+++ b/internal/pkg/client/toggl/toggl_test.go
@@ -297,8 +297,7 @@ func TestTogglClient_FetchEntries_TagsAsTasks(t *testing.T) {
 
 	togglClient, err := toggl.NewFetcher(&toggl.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasksRegex: regexp.MustCompile(`^CPT-\w+$`),
-			Timeout:          client.DefaultRequestTimeout,
+			Timeout: client.DefaultRequestTimeout,
 		},
 		BasicAuth: client.BasicAuth{
 			Username: clientUsername,
@@ -310,9 +309,10 @@ func TestTogglClient_FetchEntries_TagsAsTasks(t *testing.T) {
 	require.Nil(t, err)
 
 	entries, err := togglClient.FetchEntries(context.Background(), &client.FetchOpts{
-		User:  "987654321",
-		Start: start,
-		End:   end,
+		User:             "987654321",
+		Start:            start,
+		End:              end,
+		TagsAsTasksRegex: regexp.MustCompile(`^CPT-\w+$`),
 	})
 
 	require.Nil(t, err, "cannot fetch entries")

--- a/internal/pkg/client/toggl/toggl_test.go
+++ b/internal/pkg/client/toggl/toggl_test.go
@@ -297,7 +297,6 @@ func TestTogglClient_FetchEntries_TagsAsTasks(t *testing.T) {
 
 	togglClient, err := toggl.NewFetcher(&toggl.ClientOpts{
 		BaseClientOpts: client.BaseClientOpts{
-			TagsAsTasks:      true,
 			TagsAsTasksRegex: regexp.MustCompile(`^CPT-\w+$`),
 			Timeout:          client.DefaultRequestTimeout,
 		},

--- a/internal/pkg/utils/regex.go
+++ b/internal/pkg/utils/regex.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"regexp"
+)
+
+// IsRegexSet returns true if the regex is not nil nor an empty string,
+// otherwise, it returns false.
+func IsRegexSet(r *regexp.Regexp) bool {
+	return r != nil && r.String() != ""
+}

--- a/internal/pkg/utils/regex_test.go
+++ b/internal/pkg/utils/regex_test.go
@@ -1,0 +1,23 @@
+package utils_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/gabor-boros/minutes/internal/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRegexSet(t *testing.T) {
+	re := regexp.MustCompile("^$")
+	require.True(t, utils.IsRegexSet(re))
+}
+
+func TestIsRegexSet_EmptyString(t *testing.T) {
+	re := regexp.MustCompile("")
+	require.False(t, utils.IsRegexSet(re))
+}
+
+func TestIsRegexSet_NilPointer(t *testing.T) {
+	require.False(t, utils.IsRegexSet(nil))
+}

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -48,7 +48,6 @@ On Linux/Unix systems, the following locations are checked for the configuration
 | table-truncate-column   | map[string]int                                      | Truncate text in the given column to contain no more than `x` characters, where `x` is set by `int`                                           | table-truncate-column = { summary = 30 }              |                                                                                  |
 | target                  | string                                              | Set the upload target name                                                                                                                    | target = "tempo"                                      | Check the list of available targets                                              |
 | target-user             | string                                              | Set the upload target user ID                                                                                                                 | target = "gabor-boros"                                |                                                                                  |
-| tags-as-tasks           | bool                                                | Treat tags matching the value of `tags-as-tasks-regex` as tasks                                                                               | tags-as-tasks = true                                  |                                                                                  |
 | tags-as-tasks-regex     | string                                              | Regex of the task pattern                                                                                                                     | tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'            |                                                                                  |
 
 ## Source and target specific configuration
@@ -75,7 +74,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 round-to-closest-minute = true
 force-billed-duration = true

--- a/www/docs/getting-started.md
+++ b/www/docs/getting-started.md
@@ -43,7 +43,6 @@ Flags:
       --table-sort-by strings        sort table by column [task summary project client start end billable unbillable] (default [start,project,task,summary])
   -t, --target string                set the target of the sync [tempo]
       --target-user string           set the source user ID
-      --tags-as-tasks                treat tags matching the value of tags-as-tasks-regex as tasks
       --tags-as-tasks-regex string   regex of the task pattern
       --tempo-password string        set the login password
       --tempo-url string             set the base URL
@@ -79,7 +78,7 @@ $ minutes --date-format "2006-01-02" --start "2021-10-07" --end "2021-10-08"
 
 ```shell
 # Specify how a tag should look like to be considered as a task
-$ minutes --tags-as-tasks --tags-as-tasks-regex '[A-Z]{2,7}-\d{1,6}'
+$ minutes --tags-as-tasks-regex '[A-Z]{2,7}-\d{1,6}'
 ```
 
 ### Minute based rounding

--- a/www/docs/migrations/tempoit.md
+++ b/www/docs/migrations/tempoit.md
@@ -22,7 +22,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 round-to-closest-minute = true
 force-billed-duration = true

--- a/www/docs/migrations/toggl-tempo-worklog-transfer.md
+++ b/www/docs/migrations/toggl-tempo-worklog-transfer.md
@@ -27,7 +27,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 round-to-closest-minute = true
 force-billed-duration = true

--- a/www/docs/sources/clockify.md
+++ b/www/docs/sources/clockify.md
@@ -6,8 +6,8 @@ The source makes the following special mappings.
 
 | From        | To                     | Description                                                                                                                                         |
 | ----------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Tags        | Task                   | Turns tags into tasks and split the entry into as many pieces as the item has matching tags when `tags-as-tasks` is enabled                         |
-| Task        | Summary or Description | Tasks will be used for defining the summary of an entry; in case the `tags-as-tasks` is enabled, Summary will be set to the Description of the item |
+| Tags        | Task                   | Turns tags into tasks and split the entry into as many pieces as the item has matching tags when `tags-as-tasks-regex` is set                         |
+| Task        | Summary or Description | Tasks will be used for defining the summary of an entry; in case the `tags-as-tasks-regex` is set, Summary will be set to the Description of the item |
 
 ## CLI flags
 
@@ -54,7 +54,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 
 round-to-closest-minute = true

--- a/www/docs/sources/tempo.md
+++ b/www/docs/sources/tempo.md
@@ -7,7 +7,7 @@ The source makes the following special mappings.
 | From       | To      | Description                                                                                                                                         |
 | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | AccountKey | Client  |                                                                                                                                                     |
-| ProjectKey | Project | Tasks will be used for defining the summary of an entry; in case the `tags-as-tasks` is enabled, Summary will be set to the Description of the item |
+| ProjectKey | Project | Tasks will be used for defining the summary of an entry; in case the `tags-as-tasks-regex` is set, Summary will be set to the Description of the item |
 | IssueKey   | Task    |                                                                                                                                                     |
 | Comment    | Notes   |                                                                                                                                                     |
 
@@ -57,7 +57,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 round-to-closest-minute = true
 force-billed-duration = true

--- a/www/docs/sources/timewarrior.md
+++ b/www/docs/sources/timewarrior.md
@@ -15,7 +15,7 @@ Therefore, several assumptions were made to integrate with Timewarrior, though t
 
 !!! warning
 
-    To extract tasks from tags, set the `tags-as-tasks-regex` regardless the value of `tags-as-tasks`.
+    To extract tasks from tags, set the `tags-as-tasks-regex`.
 
 ## Field mappings
 
@@ -77,7 +77,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 round-to-closest-minute = true
 force-billed-duration = true

--- a/www/docs/sources/toggl.md
+++ b/www/docs/sources/toggl.md
@@ -67,7 +67,6 @@ tempo-username = "<jira username>"
 tempo-password = "<jira password>"
 
 # General config
-tags-as-tasks = true
 tags-as-tasks-regex = '[A-Z]{2,7}-\d{1,6}'
 round-to-closest-minute = true
 force-billed-duration = true


### PR DESCRIPTION
## Description

This PR refactors the way of tag parsing works and removes not needed arguments.

## Supporting information

The tag parsing configuration was too verbose and did not add any extra value. By simplifying the tag parsing it is easier to maintain.

### Dependencies

N/A

### Screenshots

N/A

## Testing instructions

1. Run `minutes` as without the remove config option

## Other information

This PR unifies the empty regex checking as well.

## Checklist

- [x] Documentation is updated
- [x] Pull request is rebased onto main
- [x] Commit history is clean
