### PR TITLE
Fix Clockify tag handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+**Bug Fixes**
+
+- Summary is filled if description exists ([557e286](https://github.com/gabor-boros/minutes/commit/557e286110be54733511791083b3fa0f92b0d38e))
+- Return single item entries if no tags given ([405c405](https://github.com/gabor-boros/minutes/commit/405c405518b09228d455b32543b9486b6625d4fa))
+
 **Documentation**
 
 - Fix comment wording ([cb3b3bb](https://github.com/gabor-boros/minutes/commit/cb3b3bb9763bdb6c68d5e93d5f7f16de0605abfe))

--- a/internal/pkg/client/clockify/clockify.go
+++ b/internal/pkg/client/clockify/clockify.go
@@ -107,6 +107,12 @@ func (c *clockifyClient) parseEntries(rawEntries interface{}, opts *client.Fetch
 			UnbillableDuration: unbillableDuration,
 		}
 
+		// If the entry's summary is empty, but we have notes, let's use notes for summary too
+		// See: https://github.com/gabor-boros/minutes/issues/38
+		if worklogEntry.Summary == "" && worklogEntry.Notes != "" {
+			worklogEntry.Summary = worklogEntry.Notes
+		}
+
 		if utils.IsRegexSet(opts.TagsAsTasksRegex) && len(entry.Tags) > 0 {
 			pageEntries := worklogEntry.SplitByTagsAsTasks(entry.Description, opts.TagsAsTasksRegex, entry.Tags)
 			entries = append(entries, pageEntries...)

--- a/internal/pkg/worklog/entry.go
+++ b/internal/pkg/worklog/entry.go
@@ -94,7 +94,13 @@ func (e *Entry) SplitDuration(parts int) (splitBillableDuration time.Duration, s
 // SplitByTagsAsTasks splits the entry into pieces treating tags as tasks.
 // Not matching tags won't be treated as a new entry should be created,
 // therefore that tag will be skipped and the returned entries will lack that.
+// If no tags are provided, the original entry will be returned as the only item
+// of the `Entries` list.
 func (e *Entry) SplitByTagsAsTasks(summary string, regex *regexp.Regexp, tags []IDNameField) Entries {
+	if len(tags) == 0 {
+		return Entries{*e}
+	}
+
 	var tasks []IDNameField
 	for _, tag := range tags {
 		if taskName := regex.FindString(tag.Name); taskName != "" {


### PR DESCRIPTION
## Description

Using Clockify and the settings below, both Task and Summary columns' values are missing if no tag is set. This PR fixes that issue and a smaller hidden issue.

## Supporting information

Fixes https://github.com/gabor-boros/minutes/issues/38

### Dependencies

N/A

### Screenshots

N/A

## Testing instructions

1. create a new entry in Clockify with a title set, but no task or tags are assigned
1. run minutes

## Other information

N/A

## Checklist

- [x] Documentation is updated
- [x] Pull request is rebased onto main
- [x] Commit history is clean
